### PR TITLE
Add an exception type that can be converted to I18nMessage

### DIFF
--- a/cjwmodule/http/errors.py
+++ b/cjwmodule/http/errors.py
@@ -1,20 +1,12 @@
-from cjwmodule.i18n import I18nMessage, _trans_cjwmodule
+from cjwmodule.i18n import I18nMessage, InternationalizedException, _trans_cjwmodule
 
 __all__ = ["HttpError"]
 
 
-class HttpError(Exception):
+class HttpError(InternationalizedException):
     """
     An HTTP request did not complete.
     """
-
-    @property
-    def i18n_message(self) -> I18nMessage:
-        """A message descrbing the error to the user. 
-        
-        Must be overriden by subclasses.
-        """
-        raise NotImplementedError()
 
 
 class HttpErrorTimeout(HttpError):

--- a/cjwmodule/i18n/__init__.py
+++ b/cjwmodule/i18n/__init__.py
@@ -1,4 +1,4 @@
 from .funcs import _trans_cjwmodule, trans
-from .types import I18nMessage
+from .types import I18nMessage, InternationalizedException
 
-__all__ = ["I18nMessage", "trans", "_trans_cjwmodule"]
+__all__ = ["I18nMessage", "InternationalizedException", "trans", "_trans_cjwmodule"]

--- a/cjwmodule/i18n/el.po
+++ b/cjwmodule/i18n/el.po
@@ -19,23 +19,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: http/errors.py:24
+#: http/errors.py:16
 msgid "http.errors.HttpErrorTimeout"
 msgstr ""
 
-#: http/errors.py:33
+#: http/errors.py:25
 msgid "http.errors.HttpErrorInvalidUrl"
 msgstr ""
 
-#: http/errors.py:43
+#: http/errors.py:35
 msgid "http.errors.HttpErrorTooManyRedirects"
 msgstr ""
 
-#: http/errors.py:56
+#: http/errors.py:48
 msgid "http.errors.HttpErrorNotSuccess"
 msgstr ""
 
-#: http/errors.py:73
+#: http/errors.py:65
 msgid "http.errors.HttpErrorGeneric"
 msgstr ""
 

--- a/cjwmodule/i18n/en.po
+++ b/cjwmodule/i18n/en.po
@@ -19,23 +19,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: http/errors.py:24
+#: http/errors.py:16
 msgid "http.errors.HttpErrorTimeout"
 msgstr "HTTP request timed out."
 
-#: http/errors.py:33
+#: http/errors.py:25
 msgid "http.errors.HttpErrorInvalidUrl"
 msgstr "Invalid URL. Please supply a valid URL, starting with http:// or https://."
 
-#: http/errors.py:43
+#: http/errors.py:35
 msgid "http.errors.HttpErrorTooManyRedirects"
 msgstr "HTTP server(s) redirected us too many times. Please try a different URL."
 
-#: http/errors.py:56
+#: http/errors.py:48
 msgid "http.errors.HttpErrorNotSuccess"
 msgstr "Error from server: HTTP {status_code} {reason}"
 
-#: http/errors.py:73
+#: http/errors.py:65
 msgid "http.errors.HttpErrorGeneric"
 msgstr "Error during HTTP request: {type}"
 

--- a/cjwmodule/i18n/types.py
+++ b/cjwmodule/i18n/types.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-__all__ = ["I18nMessage"]
+__all__ = ["I18nMessage", "InternationalizedException"]
 
 I18nMessage = namedtuple("I18nMessage", ["id", "arguments", "source"])
 """
@@ -18,3 +18,15 @@ manipulate ``.po`` files.
 :param source: Indication of where the message is coming from (`"module"` or `"cjwmodule"`).
 :type source: str
 """
+
+
+class InternationalizedException(Exception):
+    """ An exception that can be converted to an `I18nMessage`."""
+
+    @property
+    def i18n_message(self) -> I18nMessage:
+        """A message descrbing the error to the user.
+
+        Must be overriden by subclasses.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
A lot of modules will need to do something like 

```python

class FancyErrorOne(InternationalizedException):
    @property
    def i18n_message(self):
        return i18n.trans(...)

class FancyErrorTwo(InternationalizedException):
    @property
    def i18n_message(self):
        return i18n.trans(...)

def render(*):
    try:
        stuff = _make_stuff(*)
        return _do_things(stuff)
    except InternationalizedException as err:
        return err.i18n_message
```

This pull request provides a uniform way to define this kind of exceptions