### PR TITLE
cjwmodule.util.rowranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ package for its handy utilities:
 
 * `cjwmodule.http`: HTTP helpers, including the handy `httpfile` format.
 * `cjwmodule.i18n`: A `trans()` function for producing translatable text.
-* `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
 * `cjwmodule.testing`: Functions to help in unit testing.
+* `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
 
 Developing
 ==========
@@ -24,6 +24,7 @@ I18n
 ====
 
 ### Marking strings for translation
+
 Strings in `cjwmodule` can be marked for translation using `cjwmodule.i18n._trans_cjwmodule`.
 Each translation message must have a (unique) ID. ICU is supported for the content.
 For example,
@@ -46,6 +47,7 @@ without_arguments = _trans_cjwmodule(
 Workbench is wired to accept the return value of `_trans_cjwmodule` wherever an error/warning or quick fix is expected.
 
 ### Creating `po` catalogs
+
 Calls to `_trans_cjwmodule` can (and must) be automatically parsed to create `cjwmodule`'s `po` message files.
 This is accomplished by
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ package for its handy utilities:
 * `cjwmodule.i18n`: A `trans()` function for producing translatable text.
 * `cjwmodule.testing`: Functions to help in unit testing.
 * `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
+* `cjwmodule.util.rowranges`: Functions to help build parse row ranges.
 
 Developing
 ==========

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ package for its handy utilities:
 * `cjwmodule.i18n`: A `trans()` function for producing translatable text.
 * `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
 
-
 Developing
 ==========
 
@@ -23,6 +22,7 @@ features; fix bugs. Never change functionality.
 I18n
 ====
 
+### Marking strings for translation
 Strings in `cjwmodule` can be marked for translation using `cjwmodule.i18n._trans_cjwmodule`.
 Each translation message must have a (unique) ID. ICU is supported for the content.
 For example,
@@ -31,19 +31,40 @@ from cjwmodule.i18n import _trans_cjwmodule
 
 err = "Error 404"
 
-_trans_cjwmodule(
+with_arguments = _trans_cjwmodule(
     "greatapi.exception.message",
     "Something is wrong: {error}",
     {"error": err}
 )
+
+without_arguments = _trans_cjwmodule(
+    "greatapi.exception.general",
+    "Something is wrong",
+)
 ```
 Workbench is wired to accept the return value of `_trans_cjwmodule` wherever an error/warning or quick fix is expected.
 
+### Creating `po` catalogs
 Calls to `_trans_cjwmodule` can (and must) be automatically parsed to create `cjwmodule`'s `po` message files.
 This is accomplished by
 ```
 python maintenance/i18n.py extract
 ```
+
+### Unit testing
+
+In case a `_trans_cjwmodule` invocation needs to be unit tested, you can use `cjwmodule.util.tests.CjwmoduleI18nMessage` 
+in a manner similar to the following: 
+
+```python
+from cjwmodule.util.tests import CjwmoduleI18nMessage
+import with_arguments, without_arguments
+
+assert with_arguments == CjwmoduleI18nMessage("greatapi.exception.message", {"error": "Error 404"})
+assert without_arguments == CjwmoduleI18nMessage("greatapi.exception.general")
+```
+
+### Message deprecation
 
 For backwards compatibility, *messages in `cjwmodule`'s `po` files are never deleted*!
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ package for its handy utilities:
 * `cjwmodule.http`: HTTP helpers, including the handy `httpfile` format.
 * `cjwmodule.i18n`: A `trans()` function for producing translatable text.
 * `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
-* `cjwmodule.util.tests`: Functions to help in unit testing.
+* `cjwmodule.testing`: Functions to help in unit testing.
 
 Developing
 ==========
@@ -54,15 +54,15 @@ python maintenance/i18n.py extract
 
 ### Unit testing
 
-In case a `_trans_cjwmodule` invocation needs to be unit tested, you can use `cjwmodule.util.tests.CjwmoduleI18nMessage` 
+In case a `_trans_cjwmodule` invocation needs to be unit tested, you can use `cjwmodule.testing.i18n.cjwmodule_i18n_message` 
 in a manner similar to the following: 
 
 ```python
-from cjwmodule.util.tests import CjwmoduleI18nMessage
+from cjwmodule.testing.i18n import cjwmodule_i18n_message
 import with_arguments, without_arguments
 
-assert with_arguments == CjwmoduleI18nMessage("greatapi.exception.message", {"error": "Error 404"})
-assert without_arguments == CjwmoduleI18nMessage("greatapi.exception.general")
+assert with_arguments == cjwmodule_i18n_message("greatapi.exception.message", {"error": "Error 404"})
+assert without_arguments == cjwmodule_i18n_message("greatapi.exception.general")
 ```
 
 ### Message deprecation

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ package for its handy utilities:
 * `cjwmodule.http`: HTTP helpers, including the handy `httpfile` format.
 * `cjwmodule.i18n`: A `trans()` function for producing translatable text.
 * `cjwmodule.util.colnames`: Functions to help build a valid table's column names.
+* `cjwmodule.util.tests`: Functions to help in unit testing.
 
 Developing
 ==========

--- a/cjwmodule/i18n/el.po
+++ b/cjwmodule/i18n/el.po
@@ -39,3 +39,7 @@ msgstr ""
 msgid "http.errors.HttpErrorGeneric"
 msgstr ""
 
+#: util/rowranges.py:13
+msgid "badParam.rows.invalidRange"
+msgstr ""
+

--- a/cjwmodule/i18n/en.po
+++ b/cjwmodule/i18n/en.po
@@ -39,3 +39,7 @@ msgstr "Error from server: HTTP {status_code} {reason}"
 msgid "http.errors.HttpErrorGeneric"
 msgstr "Error during HTTP request: {type}"
 
+#: util/rowranges.py:13
+msgid "badParam.rows.invalidRange"
+msgstr "Rows must look like \"1-2\", \"5\" or \"1-2, 5\"; got \"{value}\""
+

--- a/cjwmodule/testing/i18n.py
+++ b/cjwmodule/testing/i18n.py
@@ -2,10 +2,10 @@ from typing import Dict, Union
 
 from cjwmodule import i18n
 
-__all__ = ["I18nMessage"]
+__all__ = ["i18n_message", "cjwmodule_i18n_message"]
 
 
-def I18nMessage(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
+def i18n_message(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
     """The result of calling `i18n.trans`
 
     :param id: String message ID (e.g., "errors.notEnoughColumns").
@@ -16,7 +16,7 @@ def I18nMessage(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
     return i18n.I18nMessage(id, arguments, "module")
 
 
-def CjwmoduleI18nMessage(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
+def cjwmodule_i18n_message(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
     """An i18n message that is returned from calling an internal `cjwmodule` helper.
 
     :param id: String message ID (e.g., "errors.notEnoughColumns").

--- a/cjwmodule/util/rowranges.py
+++ b/cjwmodule/util/rowranges.py
@@ -1,0 +1,51 @@
+import re
+from typing import List, Tuple
+
+from cjwmodule import i18n
+
+
+class RangeFormatError(ValueError):
+    def __init__(self, value):
+        self.value = value
+
+    @property
+    def i18n_message(self) -> i18n.I18nMessage:
+        return i18n._trans_cjwmodule(
+            "badParam.rows.invalidRange",
+            'Rows must look like "1-2", "5" or "1-2, 5"; got "{value}"',
+            {"value": self.value},
+        )
+
+
+numbers = re.compile("(?P<first>[1-9]\d*)(?:-(?P<last>[1-9]\d*))?")
+
+
+def parse_interval(s: str) -> Tuple[int, int]:
+    """
+    Parse a string 'interval' into a tuple
+
+    >>> parse_interval('1')
+    (0, 0)
+    >>> parse_interval('1-3')
+    (0, 2)
+    >>> parse_interval('5')
+    (4, 4)
+    >>> parse_interval('hi')
+    Traceback (most recent call last):
+        ...
+    RangeFormatError: Rows must look like "1-2", "5" or "1-2, 5"; got "hi"
+    """
+    match = numbers.fullmatch(s)
+    if not match:
+        raise RangeFormatError(s)
+
+    first = int(match.group("first"))
+    last = int(match.group("last") or first)
+    return (first - 1, last - 1)
+
+
+commas = re.compile("\\s*,\\s*")
+
+
+def parse_intervals(rows: str) -> List[Tuple[int, int]]:
+    return [parse_interval(s) for s in commas.split(rows.strip()) if s.strip()]

--- a/cjwmodule/util/tests.py
+++ b/cjwmodule/util/tests.py
@@ -1,0 +1,27 @@
+from typing import Dict, Union
+
+from cjwmodule import i18n
+
+__all__ = ["I18nMessage"]
+
+
+def I18nMessage(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
+    """The result of calling `i18n.trans`
+
+    :param id: String message ID (e.g., "errors.notEnoughColumns").
+    :type id: str
+    :param arguments: Keyword arguments for the message.
+    :type arguments: Dict[str, Union[int, float, str]]
+    """
+    return i18n.I18nMessage(id, arguments, "module")
+
+
+def CjwmoduleI18nMessage(id: str, arguments: Dict[str, Union[int, float, str]] = {}):
+    """An i18n message that is returned from calling an internal `cjwmodule` helper.
+
+    :param id: String message ID (e.g., "errors.notEnoughColumns").
+    :type id: str
+    :param arguments: Keyword arguments for the message.
+    :type arguments: Dict[str, Union[int, float, str]]
+    """
+    return i18n.I18nMessage(id, arguments, "cjwmodule")

--- a/tests/http/test_httpfile.py
+++ b/tests/http/test_httpfile.py
@@ -15,6 +15,7 @@ from typing import AsyncContextManager, Iterator, List, Tuple, Union
 import pytest
 
 from cjwmodule.http import HttpError, httpfile
+from cjwmodule.util.tests import CjwmoduleI18nMessage
 
 
 @dataclass(frozen=True)
@@ -220,10 +221,9 @@ class TestDownload:
         http_server.mock_response(MockHttpResponse(404))
         with pytest.raises(HttpError.NotSuccess) as cm:
             await httpfile.download(http_server.build_url("/not-found"), Path())
-        assert cm.value.i18n_message == (
+        assert cm.value.i18n_message == CjwmoduleI18nMessage(
             "http.errors.HttpErrorNotSuccess",
             {"status_code": 404, "reason": "Not Found"},
-            "cjwmodule",
         )
 
     async def test_invalid_url(self):
@@ -271,10 +271,8 @@ class TestDownload:
         with pytest.raises(HttpError.Generic) as cm:
             async with self.download(url):
                 pass
-        assert cm.value.i18n_message == (
-            "http.errors.HttpErrorGeneric",
-            {"type": "DecodingError"},
-            "cjwmodule",
+        assert cm.value.i18n_message == CjwmoduleI18nMessage(
+            "http.errors.HttpErrorGeneric", {"type": "DecodingError"},
         )
 
 

--- a/tests/http/test_httpfile.py
+++ b/tests/http/test_httpfile.py
@@ -15,7 +15,7 @@ from typing import AsyncContextManager, Iterator, List, Tuple, Union
 import pytest
 
 from cjwmodule.http import HttpError, httpfile
-from cjwmodule.util.tests import CjwmoduleI18nMessage
+from cjwmodule.testing.i18n import cjwmodule_i18n_message
 
 
 @dataclass(frozen=True)
@@ -221,7 +221,7 @@ class TestDownload:
         http_server.mock_response(MockHttpResponse(404))
         with pytest.raises(HttpError.NotSuccess) as cm:
             await httpfile.download(http_server.build_url("/not-found"), Path())
-        assert cm.value.i18n_message == CjwmoduleI18nMessage(
+        assert cm.value.i18n_message == cjwmodule_i18n_message(
             "http.errors.HttpErrorNotSuccess",
             {"status_code": 404, "reason": "Not Found"},
         )
@@ -271,7 +271,7 @@ class TestDownload:
         with pytest.raises(HttpError.Generic) as cm:
             async with self.download(url):
                 pass
-        assert cm.value.i18n_message == CjwmoduleI18nMessage(
+        assert cm.value.i18n_message == cjwmodule_i18n_message(
             "http.errors.HttpErrorGeneric", {"type": "DecodingError"},
         )
 

--- a/tests/util/test_rowranges.py
+++ b/tests/util/test_rowranges.py
@@ -1,0 +1,34 @@
+from cjwmodule.testing.i18n import cjwmodule_i18n_message
+from cjwmodule.util.rowranges import RangeFormatError, parse_intervals
+
+
+def test_zero_gives_error():
+    try:
+        parse_intervals("0-1")
+        assert False
+    except RangeFormatError as err:
+        assert err.i18n_message == cjwmodule_i18n_message(
+            "badParam.rows.invalidRange", {"value": "0-1"}
+        )
+
+
+def test_non_numeric_gives_error():
+    try:
+        parse_intervals("hi")
+        assert False
+    except RangeFormatError as err:
+        assert err.i18n_message == cjwmodule_i18n_message(
+            "badParam.rows.invalidRange", {"value": "hi"}
+        )
+
+
+def test_single_row():
+    assert parse_intervals("5") == [(4, 4)]
+
+
+def test_single_range():
+    assert parse_intervals("1-3") == [(0, 2)]
+
+
+def test_mutliple_ranges():
+    assert parse_intervals("1, 3-5,9") == [(0, 0), (2, 4), (8, 8)]


### PR DESCRIPTION
The same code to parse row ranges currently exists both in `droprowsbyposition` and `rowstoheader`. It can be moved into `cjwmodule`.

Notice: This pull request depends on #3 