### PR TITLE
Support using maintenance.i18n through setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Workbench is wired to accept the return value of `_trans_cjwmodule` wherever an 
 Calls to `_trans_cjwmodule` can (and must) be automatically parsed to create `cjwmodule`'s `po` message files.
 This is accomplished by
 ```
-python maintenance/i18n.py extract
+./setup.py extract_messages
 ```
 
 For backwards compatibility, *messages in `cjwmodule`'s `po` files are never deleted*!

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -1,3 +1,0 @@
-from .i18n import ExtractMessagesCommand
-
-__all__ = ["ExtractMessagesCommand"]

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -1,0 +1,3 @@
+from .i18n import ExtractMessagesCommand
+
+__all__ = ["ExtractMessagesCommand"]

--- a/maintenance/i18n.py
+++ b/maintenance/i18n.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import distutils.cmd
 import os
 import pathlib
 import re
@@ -232,37 +231,8 @@ def assert_messages_are_same(message: Message, other_message: Message):
     )
 
 
-class ExtractMessagesCommand(distutils.cmd.Command):
-    """A custom command to run i18n-related stuff."""
-
-    description = "extract i18n messages or check if they need extraction"
-    user_options = [
-        # The format is (long option, short option, description).
-        (
-            "check",
-            None,
-            "Check if all messages have been extracted without modifying catalogs",
-        ),
-    ]
-
-    def initialize_options(self):
-        """Set default values for options."""
-        # Each user option must be listed here with their default value.
-        self.check = False
-
-    def finalize_options(self):
-        """Post-process options."""
-
-    def run(self):
-        """Run command."""
-        if self.check:
-            check()
-        else:
-            extract()
-
-
 if __name__ == "__main__":
-    # This enrty point will be deprecated, in favour of using the distutils command above
+    # This enrty point will be deprecated, in favour of using the distutils command in setup.py
     import sys
 
     mode = sys.argv[1] if len(sys.argv) > 1 else None

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from os.path import dirname, join
 
 from setuptools import find_packages, setup
 
+import maintenance.i18n
 from cjwmodule import __version__
 
 # We use the README as the long_description
@@ -34,4 +35,5 @@ setup(
         "tests": ["pytest~=5.3.0", "pytest-asyncio~=0.10.0"],
         "maintenance": ["babel~=2.8.0"],
     },
+    cmdclass={"extract_messages": maintenance.i18n.ExtractMessagesCommand,},
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os.path import dirname, join
 
 from setuptools import find_packages, setup
 
-import maintenance.i18n
+import maintenance
 from cjwmodule import __version__
 
 # We use the README as the long_description

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,48 @@
 #!/usr/bin/env python3
 
+import distutils.cmd
 import sys
 from os.path import dirname, join
 
 from setuptools import find_packages, setup
 
-import maintenance
 from cjwmodule import __version__
 
 # We use the README as the long_description
 readme = open(join(dirname(__file__), "README.md")).read()
 
 needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+
+
+class ExtractMessagesCommand(distutils.cmd.Command):
+    """A custom command to run i18n-related stuff."""
+
+    description = "extract i18n messages or check if they need extraction"
+    user_options = [
+        # The format is (long option, short option, description).
+        (
+            "check",
+            None,
+            "Check if all messages have been extracted without modifying catalogs",
+        ),
+    ]
+
+    def initialize_options(self):
+        """Set default values for options."""
+        # Each user option must be listed here with their default value.
+        self.check = False
+
+    def finalize_options(self):
+        """Post-process options."""
+
+    def run(self):
+        from maintenance.i18n import check, extract
+
+        """Run command."""
+        if self.check:
+            check()
+        else:
+            extract()
 
 
 setup(
@@ -35,5 +66,5 @@ setup(
         "tests": ["pytest~=5.3.0", "pytest-asyncio~=0.10.0"],
         "maintenance": ["babel~=2.8.0"],
     },
-    cmdclass={"extract_messages": maintenance.ExtractMessagesCommand,},
+    cmdclass={"extract_messages": ExtractMessagesCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
         "tests": ["pytest~=5.3.0", "pytest-asyncio~=0.10.0"],
         "maintenance": ["babel~=2.8.0"],
     },
-    cmdclass={"extract_messages": maintenance.i18n.ExtractMessagesCommand,},
+    cmdclass={"extract_messages": maintenance.ExtractMessagesCommand,},
 )


### PR DESCRIPTION
The old `python maintenance/i18n.py` entrypoint can be deprecated after travis starts using `setup.py extract_messages --check`. The name `extract_messages` was chosen because it overrides a command of `pybabel`.