### PR TITLE
Fixes for messages catalogs

### DIFF
--- a/cjwmodule/i18n/_deprecated_i18n_messages.py
+++ b/cjwmodule/i18n/_deprecated_i18n_messages.py
@@ -1,0 +1,7 @@
+# This file should not be executed. Workbench extracts obsolete messages from it.
+# Even far into the future, users may see these messages. Translators must
+# translate them.
+#
+# When removing a message or changing its id, move the old message
+# (i.e. the call to `_trans_cjwmodule`) here.
+#

--- a/cjwmodule/i18n/el.po
+++ b/cjwmodule/i18n/el.po
@@ -39,23 +39,23 @@ msgstr ""
 msgid "http.errors.HttpErrorGeneric"
 msgstr ""
 
-#: util/colnames.py:402
+#: util/colnames.py:400
 msgid "util.colnames.warnings.ascii_cleaned"
 msgstr ""
 
-#: util/colnames.py:416
+#: util/colnames.py:412
 msgid "util.colnames.warnings.default"
 msgstr ""
 
-#: util/colnames.py:429
+#: util/colnames.py:423
 msgid "util.colnames.warnings.truncated"
 msgstr ""
 
-#: util/colnames.py:446
+#: util/colnames.py:438
 msgid "util.colnames.warnings.numbered"
 msgstr ""
 
-#: util/colnames.py:459
+#: util/colnames.py:449
 msgid "util.colnames.warnings.unicode_fixed"
 msgstr ""
 

--- a/cjwmodule/i18n/en.po
+++ b/cjwmodule/i18n/en.po
@@ -39,23 +39,35 @@ msgstr "Error from server: HTTP {status_code} {reason}"
 msgid "http.errors.HttpErrorGeneric"
 msgstr "Error during HTTP request: {type}"
 
-#: util/colnames.py:402
+#: util/colnames.py:400
 msgid "util.colnames.warnings.ascii_cleaned"
 msgstr ""
+"Removed special characters from {n_columns, plural, other{# column names "
+"(see “{first_colname}”)} one{column name “{first_colname}”}}"
 
-#: util/colnames.py:416
+#: util/colnames.py:412
 msgid "util.colnames.warnings.default"
 msgstr ""
+"{n_columns, plural, other{Renamed # column names because values were "
+"empty (see “{first_colname}”)} one{Renamed column name “{first_colname}” "
+"because value was empty}}"
 
-#: util/colnames.py:429
+#: util/colnames.py:423
 msgid "util.colnames.warnings.truncated"
 msgstr ""
+"{n_columns, plural, other{Truncated # column names to {n_bytes} bytes "
+"each (see “{first_colname}”)} one{Truncated column name “{first_colname}”"
+" to {n_bytes} bytes}}"
 
-#: util/colnames.py:446
+#: util/colnames.py:438
 msgid "util.colnames.warnings.numbered"
 msgstr ""
+"{n_columns, plural, other{Renamed # duplicate column names (see "
+"“{first_colname}”)} one{Renamed duplicate column name “{first_colname}”}}"
 
-#: util/colnames.py:459
+#: util/colnames.py:449
 msgid "util.colnames.warnings.unicode_fixed"
 msgstr ""
+"{n_columns, plural, other{Fixed # column names with invalid Unicode (see "
+"“{first_colname}”)} one{Fixed Unicode in column name “{first_colname}”}}"
 

--- a/cjwmodule/util/colnames.py
+++ b/cjwmodule/util/colnames.py
@@ -399,13 +399,11 @@ def gen_unique_clean_colnames_and_warn(
         warnings.append(
             _trans_cjwmodule(
                 "util.colnames.warnings.ascii_cleaned",
-                (
-                    "Removed special characters from "
-                    "{n_columns, plural,"
-                    " other{# column names (see “{first_colname}”)}"
-                    " one{column name “{first_colname}”}"
-                    "}"
-                ),
+                "Removed special characters from "
+                "{n_columns, plural,"
+                " other{# column names (see “{first_colname}”)}"
+                " one{column name “{first_colname}”}"
+                "}",
                 {"n_columns": n_ascii_cleaned, "first_colname": first_ascii_cleaned},
             )
         )
@@ -413,12 +411,10 @@ def gen_unique_clean_colnames_and_warn(
         warnings.append(
             _trans_cjwmodule(
                 "util.colnames.warnings.default",
-                (
-                    "{n_columns, plural,"
-                    " other{Renamed # column names because values were empty (see “{first_colname}”)}"
-                    " one{Renamed column name “{first_colname}” because value was empty}"
-                    "}"
-                ),
+                "{n_columns, plural,"
+                " other{Renamed # column names because values were empty (see “{first_colname}”)}"
+                " one{Renamed column name “{first_colname}” because value was empty}"
+                "}",
                 {"n_columns": n_default, "first_colname": first_default},
             )
         )
@@ -426,12 +422,10 @@ def gen_unique_clean_colnames_and_warn(
         warnings.append(
             _trans_cjwmodule(
                 "util.colnames.warnings.truncated",
-                (
-                    "{n_columns, plural,"
-                    " other{Truncated # column names to {n_bytes} bytes each (see “{first_colname}”)}"
-                    " one{Truncated column name “{first_colname}” to {n_bytes} bytes}"
-                    "}"
-                ),
+                "{n_columns, plural,"
+                " other{Truncated # column names to {n_bytes} bytes each (see “{first_colname}”)}"
+                " one{Truncated column name “{first_colname}” to {n_bytes} bytes}"
+                "}",
                 {
                     "n_columns": n_truncated,
                     "first_colname": first_truncated,
@@ -443,12 +437,10 @@ def gen_unique_clean_colnames_and_warn(
         warnings.append(
             _trans_cjwmodule(
                 "util.colnames.warnings.numbered",
-                (
-                    "{n_columns, plural,"
-                    " other{Renamed # duplicate column names (see “{first_colname}”)}"
-                    " one{Renamed duplicate column name “{first_colname}”}"
-                    "}"
-                ),
+                "{n_columns, plural,"
+                " other{Renamed # duplicate column names (see “{first_colname}”)}"
+                " one{Renamed duplicate column name “{first_colname}”}"
+                "}",
                 {"n_columns": n_numbered, "first_colname": first_numbered},
             )
         )
@@ -456,12 +448,10 @@ def gen_unique_clean_colnames_and_warn(
         warnings.append(
             _trans_cjwmodule(
                 "util.colnames.warnings.unicode_fixed",
-                (
-                    "{n_columns, plural,"
-                    " other{Fixed # column names with invalid Unicode (see “{first_colname}”)}"
-                    " one{Fixed Unicode in column name “{first_colname}”}"
-                    "}"
-                ),
+                "{n_columns, plural,"
+                " other{Fixed # column names with invalid Unicode (see “{first_colname}”)}"
+                " one{Fixed Unicode in column name “{first_colname}”}"
+                "}",
                 {"n_columns": n_unicode_fixed, "first_colname": first_unicode_fixed},
             )
         )

--- a/maintenance/i18n.py
+++ b/maintenance/i18n.py
@@ -151,9 +151,15 @@ def _update_catalog(
     for message in pot_catalog:
         if message.id:
             old_message = catalog.get(message.id)
-            new_string = default_messages.get(
-                message.id, old_message.string if old_message else ""
-            )
+            if default_messages:
+                try:
+                    new_string = default_messages[message.id]
+                except KeyError as err:
+                    raise ValueError(
+                        "Missing default message for %s" % message.id
+                    ) from err
+            else:
+                new_string = old_message.string if old_message else ""
             if old_message:
                 catalog.delete(message.id)
             catalog.add(


### PR DESCRIPTION
1. Looks like `pybabel` ignores the default message if it's enclosed in parentheses, hence some messages in the English po catalog were empty.
2. Added a check for missing default messages during extraction.
3. The extraction script now deletes messages that are not in the code. Added a file where deprecated messages should be placed for backwards compatibility.