### PR TITLE
Add some functions in testing

### DIFF
--- a/cjwmodule/testing/http.py
+++ b/cjwmodule/testing/http.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Union
+
+__all__ = ["MockHttpResponse"]
+
+
+@dataclass(frozen=True)
+class MockHttpResponse:
+    status_code: int = 200
+    """HTTP status code"""
+
+    headers: List[Tuple[str, str]] = field(default_factory=list)
+    """List of headers -- including Content-Length, Transfer-Encoding, etc."""
+
+    body: Union[bytes, List[bytes]] = b""
+    """
+    HTTP response body.
+
+    If this is `bytes` (including the default, `b""`), then `headers` requires
+    a `Content-Length`. If this is a `List[bytes]`, then `headers` requires
+    `Transfer-Encoding: chunked`.
+    """
+
+    @classmethod
+    def ok(
+        cls, body: bytes = b"", headers: List[Tuple[str, str]] = []
+    ) -> MockHttpResponse:
+        if isinstance(body, bytes):
+            if not any(h[0].upper() == "CONTENT-LENGTH" for h in headers):
+                # do not append to `headers`: create a new list
+                headers = headers + [("Content-Length", str(len(body)))]
+        elif isinstance(body, list):
+            if not any(h[0].upper() == "TRANSFER-ENCODING" for h in headers):
+                # do not append to `headers`: create a new list
+                headers = headers + [("Transfer-Encoding", "chunked")]
+        else:
+            raise TypeError("body must be bytes or List[bytes]; got %r" % type(body))
+        return cls(status_code=200, body=body, headers=headers)

--- a/cjwmodule/testing/params.py
+++ b/cjwmodule/testing/params.py
@@ -1,0 +1,14 @@
+__all__ = ["MockParams"]
+
+
+class MockParams:
+    @staticmethod
+    def factory(**kwargs):
+        """Build a MockParams factory with default values.
+
+        Usage:
+
+            P = MockParams.factory(foo=3)
+            params = P(bar=2)  # {'foo': 3, 'bar': 2}
+        """
+        return lambda **d: {**kwargs, **d}

--- a/cjwmodule/testing/settings.py
+++ b/cjwmodule/testing/settings.py
@@ -1,0 +1,21 @@
+__all__ = ["MockSettings"]
+
+
+class MockSettings:
+    @staticmethod
+    def factory(**kwargs):
+        """Build a MockSettings factory with default values.
+
+        Usage:
+
+            S = MockSettings.factory(foo=3)
+            settings = S(bar=2)  # settings.foo == 3, settings.bar == 2
+        """
+
+        def build(**d):
+            settings = MockSettings()
+            for setting, value in {**kwargs, **d}.items():
+                setattr(settings, setting, value)
+            return settings
+
+        return build

--- a/tests/http/test_httpfile.py
+++ b/tests/http/test_httpfile.py
@@ -7,49 +7,15 @@ import itertools
 import tempfile
 import threading
 import zlib
-from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import AsyncContextManager, Iterator, List, Tuple, Union
+from typing import AsyncContextManager, Iterator, Union
 
 import pytest
 
 from cjwmodule.http import HttpError, httpfile
+from cjwmodule.testing.http import MockHttpResponse
 from cjwmodule.testing.i18n import cjwmodule_i18n_message
-
-
-@dataclass(frozen=True)
-class MockHttpResponse:
-    status_code: int = 200
-    """HTTP status code"""
-
-    headers: List[Tuple[str, str]] = field(default_factory=list)
-    """List of headers -- including Content-Length, Transfer-Encoding, etc."""
-
-    body: Union[bytes, List[bytes]] = b""
-    """
-    HTTP response body.
-
-    If this is `bytes` (including the default, `b""`), then `headers` requires
-    a `Content-Length`. If this is a `List[bytes]`, then `headers` requires
-    `Transfer-Encoding: chunked`.
-    """
-
-    @classmethod
-    def ok(
-        cls, body: bytes = b"", headers: List[Tuple[str, str]] = []
-    ) -> MockHttpResponse:
-        if isinstance(body, bytes):
-            if not any(h[0].upper() == "CONTENT-LENGTH" for h in headers):
-                # do not append to `headers`: create a new list
-                headers = headers + [("Content-Length", str(len(body)))]
-        elif isinstance(body, list):
-            if not any(h[0].upper() == "TRANSFER-ENCODING" for h in headers):
-                # do not append to `headers`: create a new list
-                headers = headers + [("Transfer-Encoding", "chunked")]
-        else:
-            raise TypeError("body must be bytes or List[bytes]; got %r" % type(body))
-        return cls(status_code=200, body=body, headers=headers)
 
 
 @pytest.fixture

--- a/tests/testing/test_params.py
+++ b/tests/testing/test_params.py
@@ -1,0 +1,16 @@
+from cjwmodule.testing.params import MockParams
+
+
+def test_mock_factory_default():
+    P = MockParams.factory(p=1, q=2)
+    assert P() == {"p": 1, "q": 2}
+
+
+def test_mock_factory_non_default():
+    P = MockParams.factory()
+    assert P(p=1, q=2) == {"p": 1, "q": 2}
+
+
+def test_mock_factory_override():
+    P = MockParams.factory(p=0, q=1)
+    assert P(p=1, q=2) == {"p": 1, "q": 2}

--- a/tests/testing/test_settings.py
+++ b/tests/testing/test_settings.py
@@ -1,0 +1,22 @@
+from cjwmodule.testing.settings import MockSettings
+
+
+def test_mock_factory_default():
+    S = MockSettings.factory(p=1, q=2)
+    settings = S()
+    assert settings.p == 1
+    assert settings.q == 2
+
+
+def test_mock_factory_non_default():
+    S = MockSettings.factory()
+    settings = S(p=1, q=2)
+    assert settings.p == 1
+    assert settings.q == 2
+
+
+def test_mock_factory_override():
+    S = MockSettings.factory(p=0, q=1)
+    settings = S(p=1, q=2)
+    assert settings.p == 1
+    assert settings.q == 2


### PR DESCRIPTION
The intention of this pull request is to bring stuff from `cjworkbench.staticmodules.tests.util` into `cjwmodule.testing`.

- Copied `MockParams` from cjworkbench utils for testing staticmodules.
- Created a similar `MockSettings`, which will be useful when passing settings as parameters to `render`/`fetch`.
- Moved `MockHttpResponse` from `tests.http.test_httpfile` to `cjwmodule.testing.http`